### PR TITLE
Update code to run on modern versions of Python

### DIFF
--- a/data_elements.py
+++ b/data_elements.py
@@ -231,13 +231,13 @@ class ElementSegment(ElementMaster):
     def editions(self):
         "Iterate over the children of the Chapters element, if any."
         elt = self.child_named('Chapters')
-        if elt is None:
-            raise StopIteration
+        if elt is None: return
         yield from elt.children_named('EditionEntry')
     @property
     def chapters(self):
         "Iterate over the ChapterAtom children of the first EditionEntry."
-        edition = next(self.editions)  # May raise StopIteration
+        try: edition = next(self.editions)
+        except StopIteration: return
         yield from edition.chapters
 
     # Manipulating children

--- a/tags.py
+++ b/tags.py
@@ -137,7 +137,8 @@ class TagDict(Mapping):
             return self._dict[key]
         except KeyError:
             if isinstance(key, int):
-                return Tag(key, 'Unknown', 'ElementUnsupported', "*",
+                from .element import ElementUnsupported
+                return Tag(key, 'Unknown', ElementUnsupported, "*",
                            False, True, True, 1, 4)
             raise
 


### PR DESCRIPTION
Unsupported entities crash in trying to refer to their element tags.